### PR TITLE
Fixed issue with drag and drop and right click

### DIFF
--- a/Assets/Items/CoffeeFish.asset
+++ b/Assets/Items/CoffeeFish.asset
@@ -15,7 +15,9 @@ MonoBehaviour:
   itemName: A Cup of Joe
   itemDescription: The tasty remains of the coffee fish.
   itemSprite: {fileID: 21300000, guid: f63037a652ffd40d591e7782412c0501, type: 3}
+  durability: 100
+  durabilityDecreasePerUse: 1
   type: 1
-  itemID: 2
+  itemID: 281575035
   isStackable: 1
   maxStackSize: 16

--- a/Assets/Items/CoffeeFish.asset
+++ b/Assets/Items/CoffeeFish.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d619f7242af379649be7ecff9b14844a, type: 3}
+  m_Name: CoffeeFish
+  m_EditorClassIdentifier: 
+  itemName: A Cup of Joe
+  itemDescription: The tasty remains of the coffee fish.
+  itemSprite: {fileID: 21300000, guid: f63037a652ffd40d591e7782412c0501, type: 3}
+  type: 1
+  itemID: 2
+  isStackable: 1
+  maxStackSize: 16

--- a/Assets/Items/CoffeeFish.asset.meta
+++ b/Assets/Items/CoffeeFish.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e45de55ce7e005d4fa54c78d2efe6c1e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Items/StackableTestItem.asset
+++ b/Assets/Items/StackableTestItem.asset
@@ -17,7 +17,9 @@ MonoBehaviour:
     It's to test that the inventory system actually takes items in and stacks them
     properly.
   itemSprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
+  durability: 100
+  durabilityDecreasePerUse: 1
   type: 1
-  itemID: 0
+  itemID: 752388010
   isStackable: 1
   maxStackSize: 3

--- a/Assets/Items/UnstackableTestItem 1.asset
+++ b/Assets/Items/UnstackableTestItem 1.asset
@@ -17,7 +17,9 @@ MonoBehaviour:
     It's to test that the inventory system actually takes items in and stacks them
     properly.
   itemSprite: {fileID: 10915, guid: 0000000000000000f000000000000000, type: 0}
+  durability: 100
+  durabilityDecreasePerUse: 1
   type: 2
-  itemID: 1
+  itemID: 980141746
   isStackable: 0
   maxStackSize: 1

--- a/Assets/Prefabs/Inventory/Inventory.prefab
+++ b/Assets/Prefabs/Inventory/Inventory.prefab
@@ -302,6 +302,7 @@ GameObject:
   - component: {fileID: 5657167462813773278}
   - component: {fileID: 6207263038362582049}
   - component: {fileID: 5873629285018145284}
+  - component: {fileID: 1044287015833701927}
   m_Layer: 5
   m_Name: Background
   m_TagString: Untagged
@@ -422,6 +423,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &1044287015833701927
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8769917835269252494}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b64604beb41d1c48a73875d04d9f5e1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &848914223392299473
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Inventory/SlotItem.prefab
+++ b/Assets/Prefabs/Inventory/SlotItem.prefab
@@ -92,8 +92,10 @@ MonoBehaviour:
   image: {fileID: 426014041791693058}
   textObject: {fileID: 5771418976226629080}
   storedItem: {fileID: 0}
-  parentBeforeDrag: {fileID: 0}
+  currentStackSize: 1
   parentAfterDrag: {fileID: 0}
+  rightClicked: 0
+  draggable: 1
 --- !u!1 &2106243298119370844
 GameObject:
   m_ObjectHideFlags: 0
@@ -126,11 +128,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 8022528414965557346}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 40, y: -40}
-  m_SizeDelta: {x: 43.1736, y: 40.658}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 11, y: -22}
+  m_SizeDelta: {x: 125, y: 40.658}
+  m_Pivot: {x: 1, y: 0}
 --- !u!222 &3569558141001713108
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/InventorySystem.prefab
+++ b/Assets/Prefabs/InventorySystem.prefab
@@ -268,6 +268,7 @@ MonoBehaviour:
   testItems:
   - {fileID: 11400000, guid: 74eafb33414a35240b2c4f92e32d9201, type: 2}
   - {fileID: 11400000, guid: 25cccaf8f9011d3438a3eaa403f67292, type: 2}
+  - {fileID: 11400000, guid: e45de55ce7e005d4fa54c78d2efe6c1e, type: 2}
 --- !u!1001 &4519289602490105787
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/InventorySystemDemo.unity
+++ b/Assets/Scenes/InventorySystemDemo.unity
@@ -133,6 +133,7 @@ GameObject:
   - component: {fileID: 86172208}
   - component: {fileID: 86172207}
   - component: {fileID: 86172206}
+  - component: {fileID: 86172209}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -214,6 +215,22 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &86172209
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 86172205}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 56666c5a40171f54783dd416a44f42bf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EventMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_MaxRayIntersections: 0
 --- !u!1 &262989384
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleLaunch.unity
+++ b/Assets/Scenes/SampleLaunch.unity
@@ -173,6 +173,7 @@ GameObject:
   m_Component:
   - component: {fileID: 231421192}
   - component: {fileID: 231421191}
+  - component: {fileID: 231421194}
   - component: {fileID: 231421190}
   - component: {fileID: 231421193}
   m_Layer: 0
@@ -270,6 +271,119 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   smoothTime: 0.5
   playerObject: {fileID: 0}
+--- !u!114 &231421194
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 231421189}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 56666c5a40171f54783dd416a44f42bf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EventMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_MaxRayIntersections: 0
+--- !u!1001 &503083660
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2479236152868172386, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8033156588941166350, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
+      propertyPath: m_Name
+      value: InventorySystem
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8649920cf0e87dc47bec42c34606c208, type: 3}
 --- !u!1 &550101151
 GameObject:
   m_ObjectHideFlags: 0
@@ -853,6 +967,74 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &1753787784
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1753787787}
+  - component: {fileID: 1753787786}
+  - component: {fileID: 1753787785}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1753787785
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1753787784}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1753787786
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1753787784}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1753787787
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1753787784}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1785796285
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1456,6 +1638,7 @@ PrefabInstance:
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
+  - {fileID: 1753787787}
   - {fileID: 826521925}
   - {fileID: 3423755274367361153}
   - {fileID: 2144407625}
@@ -1466,3 +1649,4 @@ SceneRoots:
   - {fileID: 2001226112}
   - {fileID: 1785796285}
   - {fileID: 2126029707}
+  - {fileID: 503083660}

--- a/Assets/Scripts/InventorySystem/InventoryItem.cs
+++ b/Assets/Scripts/InventorySystem/InventoryItem.cs
@@ -12,8 +12,10 @@ public class InventoryItem : MonoBehaviour, IBeginDragHandler, IDragHandler, IEn
     public TMP_Text textObject;
     public Item storedItem;
     public int currentStackSize = 1;
+
     [HideInInspector] public Transform parentAfterDrag;
     [HideInInspector] public bool rightClicked = false;
+    [HideInInspector] public bool draggable = true;
 
     void Update()
     {
@@ -29,6 +31,7 @@ public class InventoryItem : MonoBehaviour, IBeginDragHandler, IDragHandler, IEn
         if (eventData.button == PointerEventData.InputButton.Right && !rightClicked)
         {
             Debug.Log("Right clicked!");
+
             rightClicked = true;
         }
     }
@@ -92,21 +95,30 @@ public class InventoryItem : MonoBehaviour, IBeginDragHandler, IDragHandler, IEn
 
     public void OnBeginDrag(PointerEventData eventData)
     {
-        parentAfterDrag = transform.parent;
-        transform.SetParent(transform.root);
-        transform.SetAsLastSibling();
-        image.raycastTarget = false;
+        if (draggable)
+        {
+            parentAfterDrag = transform.parent;
+            transform.SetParent(transform.root);
+            transform.SetAsLastSibling();
+            image.raycastTarget = false;
+        }
     }
 
     public void OnDrag(PointerEventData eventData)
     {
-        transform.position = Input.mousePosition;
+        if (draggable)
+        {
+            transform.position = Input.mousePosition;
+        }
     }
 
     public void OnEndDrag(PointerEventData eventData)
     {
-        // Check that the position is where the inventory screen or hotbar is
-        transform.SetParent(parentAfterDrag);
-        image.raycastTarget = true;
+        if (draggable)
+        {
+            // Check that the position is where the inventory screen or hotbar is
+            transform.SetParent(parentAfterDrag);
+            image.raycastTarget = true;
+        }
     }
 }

--- a/Assets/Scripts/InventorySystem/InventoryKeyHandler.cs
+++ b/Assets/Scripts/InventorySystem/InventoryKeyHandler.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class InventoryKeyHandler : MonoBehaviour
 {
     // Variables
-    [HideInInspector] public bool isShowing = false;
+    [HideInInspector] public bool isShowing = true;
     public GameObject inventory;
     public KeyCode inventoryKey = KeyCode.E;
     public int hotbarSlots = 8;
@@ -13,8 +13,8 @@ public class InventoryKeyHandler : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        // Set the inventory to be hidden at the start
-        inventory.SetActive(false);
+        // Start the inventory closed
+        CloseInventory();
 
         Debug.Log("Inventory system is active.");
     }
@@ -63,7 +63,7 @@ public class InventoryKeyHandler : MonoBehaviour
     }
 
     /// <summary>
-    /// Closes the inventory menu.
+    /// Closes the inventory menu. Also disables dragging for the hotbar items.
     /// </summary>
     public void CloseInventory()
     {
@@ -71,10 +71,13 @@ public class InventoryKeyHandler : MonoBehaviour
 
         inventory.SetActive(false);
         isShowing = false;
+
+        // Disable dragging for the hotbar items
+        InventoryManager.instance.GetComponent<InventoryManager>().SetDraggable(false);
     }
 
     /// <summary>
-    /// Opens the inventory menu.
+    /// Opens the inventory menu. Also enables dragging for the hotbar items.
     /// </summary>
     public void ShowInventory()
     {
@@ -83,6 +86,9 @@ public class InventoryKeyHandler : MonoBehaviour
         AnimateScaleChange(inventory, inventory.transform.localScale, new Vector2(1, 1));
 
         isShowing = true;
+
+        // Enable dragging for the hotbar items
+        InventoryManager.instance.GetComponent<InventoryManager>().SetDraggable(true);
     }
 
     //TODO: Animates the scale of the given gameObject from startScale to endScale

--- a/Assets/Scripts/InventorySystem/InventoryManager.cs
+++ b/Assets/Scripts/InventorySystem/InventoryManager.cs
@@ -27,12 +27,14 @@ public class InventoryManager : MonoBehaviour
         ChangeSelectedSlot(0);
 
         // Testing code; REMOVE LATER
-        AddItem(testItems[1]);
-        for (int i = 0; i < 20; i++)
+
+        bool added = AddItem(testItems[1]);
+        for (int i = 0; i < 33; i++)    // Chose a weird number of items to see if the stacks are correct
         {
             int randomIndex = Random.Range(0, testItems.Length); // Get a random index
             Item randomItem = testItems[randomIndex]; // Get the random item
-            AddItem(randomItem); // Add the item to the inventory
+            added = AddItem(randomItem); // Add the item to the inventory
+            if (!added) { break; }
         }
         GetSelectedItem(true);
         Debug.Log("Currently selected: " + GetSelectedItem().itemName + " (" + GetSelectedItem().type + ")");

--- a/Assets/Scripts/InventorySystem/InventorySlotHolder.cs
+++ b/Assets/Scripts/InventorySystem/InventorySlotHolder.cs
@@ -15,6 +15,21 @@ public class InventorySlotHolder : MonoBehaviour, IDropHandler
         DeselectSlot();
     }
 
+    public void SetDraggable(bool dragOption)
+    {
+        if (transform.childCount != 0)
+        {
+            if (dragOption)
+            {
+                transform.GetChild(0).GetComponent<InventoryItem>().draggable = true;
+            }
+            else
+            {
+                transform.GetChild(0).GetComponent<InventoryItem>().draggable = false;
+            }
+        }
+    }
+
     /// <summary>
     /// Change the color of the slot to indicate that it is selected.
     /// </summary>

--- a/Assets/Scripts/InventorySystem/Item.cs
+++ b/Assets/Scripts/InventorySystem/Item.cs
@@ -7,16 +7,35 @@ public class Item : ScriptableObject
 {
     // Item descriptors
     [Header("Visible to players")]
+    [Tooltip("The name of the item that will be displayed in the inventory.")]
     public string itemName;
     [TextArea]
+    [Tooltip("The description of the item that will be displayed in the inventory.")]
     public string itemDescription;
+    [Tooltip("The sprite that will be displayed in the inventory slot.")]
     public Sprite itemSprite;
+    [Range(0, 100)]
+    [Tooltip("The amount of durability that the item has. This value should be between 0 and 100 inclusive.")]
+    public int durability = 100;
 
     [Header("Not visible to players")]
+    [Range(1, 100)]
+    [Tooltip("The amount of durability that is decreased per use. This vaule should be between 1 and 100 inclusive.")]
+    public int durabilityDecreasePerUse;
+    [Tooltip("The type of the item.")]
     public ItemType type;
+    [Tooltip("The ID of the item. This must be unique to each item.")]
+    [ContextMenuItem("Generate a random ID", "GenerateItemID")]
     public int itemID;
+    [Tooltip("Whether the item can be stacked or not.")]
     public bool isStackable;
+    [Tooltip("The maximum amount of items that can be stacked together if stackable.")]
     public int maxStackSize;
+
+    private void GenerateItemID()
+    {
+        itemID = Random.Range(0, 999999999);
+    }
 }
 
 public enum ItemType

--- a/Assets/Sprites/InventoryBackgroundDropItem.cs
+++ b/Assets/Sprites/InventoryBackgroundDropItem.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class InventoryBackgroundDropItem : MonoBehaviour, IDropHandler
+{
+    public void OnDrop(PointerEventData eventData)
+    {
+        InventoryItem draggableItem = eventData.pointerDrag.GetComponent<InventoryItem>();
+
+        // Drop item and remove it from the inventory
+        Debug.Log("Dropped " + draggableItem.currentStackSize + " " + draggableItem.storedItem.itemName);
+
+        // Most likely give the dropped item to some other game object here before destroying it
+
+        Destroy(draggableItem.gameObject);
+    }
+}

--- a/Assets/Sprites/InventoryBackgroundDropItem.cs.meta
+++ b/Assets/Sprites/InventoryBackgroundDropItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b64604beb41d1c48a73875d04d9f5e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**Fixes**:
- Items can be dragged out of the inventory and should be dropped (currently just being removed) from the inventory.
- The Item object should have tooltips to explain what each attribute does.
- The Item object has new attributes.
- The itemID attribute in the Item object can be randomised by right-clicking the field and selecting "Generate Random itemID".
- Items are now disabled from being dragged when the inventory is not open.
- Functions for adding and using items from the inventory are now better and support adding or using multiple of the same item.
- Fixed width of item quantity label to show text in tens or hundreds properly.
- Updated test items with new item IDs.
- Added a new test item:
  - The coffee fish is a test item to see how an item with a better icon looks in the inventory.

**To-do**:
- Make a right-click context menu to view it's properties such as name and description.
- Assign right and left click (depending on item type) to decrease the durability of the currently selected hotbar item slot.
- Automatically remove an item from inventory if the durability is 0.

**Notes**:

- If the scene has a `Canvas`, it requires the following to use the `IDragHandler` (mouse events) systems:
  - An `EventSystem` game object must be in the scene hierarchy
  - The scene's camera must have a `Physics 2D Raycaster` property
  - Fix from: <https://forum.unity.com/threads/ibegindraghandler-idraghandler-ienddraghandler-script-attached-to-sprite-object.294168/>.
- Images for the inventory should be square in size otherwise it's going to be stretched or squished to fit into a square.